### PR TITLE
[FIX] Use own relocated GSON instead of hoping that the Server software has the right version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'com.gradleup.shadow' version '8.3.6'
 }
 
 group = project.plugin_group as Object
@@ -21,6 +22,16 @@ tasks.withType(JavaCompile).configureEach {
     }
 }
 
+shadowJar {
+    relocate 'com.google.gson', 'de.xtkq.libs.gson'
+}
+
+build.dependsOn shadowJar
+
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
     maven {
@@ -34,6 +45,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.google.code.gson:gson:2.13.0'
     implementation 'org.spigotmc:spigot-api:1.21.5-R0.1-SNAPSHOT'
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'


### PR DESCRIPTION
This adds GSON as a library and relocates it so that there are no Issues with other plugins doing the same.
A big "Issue" with this is that the size of the plugin is increasing a lot.