### PR TITLE
fix: replace PlayerLoginEvent with PlayerJoinEvent to resolve PaperMC warning

### DIFF
--- a/src/main/java/de/xtkq/voidgen/events/EventManager.java
+++ b/src/main/java/de/xtkq/voidgen/events/EventManager.java
@@ -5,7 +5,7 @@ import de.xtkq.voidgen.VoidGen;
 public class EventManager {
 
     private final VoidGen voidGen;
-    private PlayerLoginListener playerLogin;
+    private PlayerJoinListener playerJoin;
     private PluginEnableListener pluginEnable;
 
     public EventManager(VoidGen voidGen) {
@@ -13,13 +13,13 @@ public class EventManager {
     }
 
     public void initialize() {
-        this.playerLogin = new PlayerLoginListener(this.voidGen);
+        this.playerJoin = new PlayerJoinListener(this.voidGen);
         this.pluginEnable = new PluginEnableListener(this.voidGen);
     }
 
     public void terminate() {
-        if (this.playerLogin != null)
-            this.playerLogin.terminate();
+        if (this.playerJoin != null)
+            this.playerJoin.terminate();
         if (this.pluginEnable != null)
             this.pluginEnable.terminate();
     }

--- a/src/main/java/de/xtkq/voidgen/events/PlayerJoinListener.java
+++ b/src/main/java/de/xtkq/voidgen/events/PlayerJoinListener.java
@@ -7,21 +7,22 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 
 import java.util.concurrent.TimeUnit;
 
-public class PlayerLoginListener implements Listener {
+public class PlayerJoinListener implements Listener {
 
     private final VoidGen voidGen;
 
-    public PlayerLoginListener(VoidGen voidGen) {
+    public PlayerJoinListener(VoidGen voidGen) {
         this.voidGen = voidGen;
         this.voidGen.getServer().getPluginManager().registerEvents(this, voidGen);
     }
 
     @EventHandler(priority = EventPriority.LOW)
-    public void onPlayerLogin(PlayerLoginEvent event) {
+    public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         if (UpdateUtils.isUpdateAvailable()) {
             if (player.isOp()) {


### PR DESCRIPTION
Since versions 1.21.5/6/7, the `PlayerLoginEvent` is deprecated on PaperMC and triggers a warning like this when used:  
> [00:00:00 INFO]: [HorriblePlayerLoginEventHack] You have plugins listening to the `PlayerLoginEvent`, this will make re-configuration APIs unavailable: [VoidGen]

This event is only used to check for updates and send a message to the player if needed. So, we can easily replace this event with the `PlayerJoinEvent`, which is more appropriate in my opinion, and suppress this warning.